### PR TITLE
fix: round Paystack amounts

### DIFF
--- a/backend/controllers/booking.controller.js
+++ b/backend/controllers/booking.controller.js
@@ -4,6 +4,7 @@ import Hotel from '../models/hotel.model.js';
 import Room from '../models/room.model.js';
 import User from '../models/user.model.js';
 import axios from 'axios';
+import { toKobo } from '../utils/paystack.js';
 
 const awardLoyaltyPoint = async (bookingId) => {
     try {
@@ -293,7 +294,7 @@ export const initiatePaystackPayment = async (req, res) => {
         const initResponse = await axios.post(
             "https://api.paystack.co/transaction/initialize",
             {
-                amount: booking.totalPrice * 100,
+                amount: toKobo(booking.totalPrice),
                 email: booking.user.email,
                 reference,
                 callback_url: `${process.env.FRONTEND_URL || "http://localhost:5173"}/my-bookings`

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "server": "nodemon index.js",
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/backend/utils/paystack.js
+++ b/backend/utils/paystack.js
@@ -1,0 +1,1 @@
+export const toKobo = (amount) => Math.round(amount * 100);

--- a/backend/utils/paystack.test.js
+++ b/backend/utils/paystack.test.js
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { toKobo } from './paystack.js';
+
+test('toKobo converts non-integer totals to integer kobo', () => {
+  assert.strictEqual(toKobo(99.99), 9999);
+  assert.strictEqual(toKobo(100.75), 10075);
+});


### PR DESCRIPTION
## Summary
- ensure Paystack amount uses integer-safe conversion
- test conversion of non-integer totals

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7ca249b9c8328a61f4043d53123d2