### PR TITLE
Fix hotel registration and serve legacy uploads

### DIFF
--- a/backend/controllers/hotel.controller.js
+++ b/backend/controllers/hotel.controller.js
@@ -1,19 +1,15 @@
 import Hotel from "../models/hotel.model.js";
-import fs from "fs";
-import cloudinary from "../config/cloudinary.js";
 
 // Register a new hotel
 
-export const registerHotel = async(req, res) => {
-    const {id} = req.user
+export const registerHotel = async (req, res) => {
+    const { id } = req.user
     try {
         const { hotelName, hotelAddress, rating, price, amenities } = req.body
-        const localPath = req.file?.path
-        if(!hotelName || !hotelAddress || !rating || !price || !amenities || !localPath) {
+        const imageUrl = req.file?.path
+        if (!hotelName || !hotelAddress || !rating || !price || !amenities || !imageUrl) {
             return res.status(400).json({ message: "All fields are required", success: false })
         }
-        const uploaded = await cloudinary.uploader.upload(localPath, { folder: "hotels" })
-        fs.unlinkSync(localPath)
 
         const newHotel = new Hotel({
             hotelName,
@@ -21,7 +17,7 @@ export const registerHotel = async(req, res) => {
             rating,
             price,
             amenities,
-            image: uploaded.secure_url,
+            image: imageUrl,
             owner: id,
         })
         await newHotel.save()

--- a/backend/controllers/room.controller.js
+++ b/backend/controllers/room.controller.js
@@ -1,6 +1,4 @@
 import Room from "../models/room.model.js";
-import fs from "fs";
-import cloudinary from "../config/cloudinary.js";
 
 // Add new room
 export const addRoom = async (req, res) => {
@@ -8,13 +6,7 @@ export const addRoom = async (req, res) => {
         const { roomType, hotel, pricePerNight, description, amenities, isAvailable } = req.body
         const imageFiles = req.files || []
 
-        const uploadedImages = []
-        for (const file of imageFiles) {
-            const uploaded = await cloudinary.uploader.upload(file.path, { folder: "rooms" })
-            uploadedImages.push(uploaded.secure_url)
-            fs.unlinkSync(file.path)
-        }
-        const image = req.files?.map((file) => file.path)
+        const uploadedImages = imageFiles.map((file) => file.path)
         const newRoom = await Room.create({
             roomType,
             hotel,

--- a/backend/index.js
+++ b/backend/index.js
@@ -18,6 +18,7 @@ connectDB()
 app.use(express.json())
 app.use(cors({ origin: ["http://localhost:5173", "https://anonstay.netlify.app", "https://anonstay.up.railway.app", "https://js.paystack.co"], credentials: true }))
 app.use(cookieParser())
+app.use("/uploads", express.static("uploads"))
 
 // API ENDPOINTS
 app.get("/", (req, res) => {


### PR DESCRIPTION
## Summary
- remove duplicate Cloudinary uploads for hotels and rooms
- serve existing local images from `/uploads`

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7edde7fec83289d5a0ec908049e6b