### PR TITLE
feat: centralize image source handling

### DIFF
--- a/frontend/src/components/BookingList.jsx
+++ b/frontend/src/components/BookingList.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {
   MapPin, CreditCard, HandCoins,
   CheckCircle, Clock, XCircle,
-  Check, UserCheck, AlertTriangle, 
+  Check, UserCheck, AlertTriangle,
   Lock, CalendarX
 } from "lucide-react";
+import { getImageSrc } from '../utils/image';
 
 const getStatusTextColor = (status) => {
   switch (status) {
@@ -118,7 +119,7 @@ const BookingList = ({ bookings, loading, markAsPaid, updateStatus, confirmCheck
                 <div className='col-span-4'>
                   <div className='flex gap-4'>
                     <img
-                      src={booking.room.images[0]}
+                      src={getImageSrc(booking.room.images[0])}
                       alt={booking.room.roomType}
                       className='w-24 h-20 rounded-lg object-cover flex-shrink-0'
                     />
@@ -315,7 +316,7 @@ const BookingList = ({ bookings, loading, markAsPaid, updateStatus, confirmCheck
                 {/* Hotel Info */}
                 <div className='flex gap-2'>
                   <img
-                    src={booking.room.images[0]}
+                    src={getImageSrc(booking.room.images[0])}
                     alt={booking.room.roomType}
                     className='w-20 h-14 rounded-lg object-cover flex-shrink-0'
                   />

--- a/frontend/src/components/MostPicked.jsx
+++ b/frontend/src/components/MostPicked.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import { AppContext } from '../context/AppContext'
 import { MapPin } from 'lucide-react';
+import { getImageSrc } from '../utils/image';
 
 const MostPicked = () => {
   const { hotelData, navigate } = useContext(AppContext)
@@ -28,7 +29,7 @@ const MostPicked = () => {
               onClick={() => handleHotelClick(item._id, item.hotelName)}
             >
               <img
-                src={item.image}
+                src={getImageSrc(item.image)}
                 alt={item.hotelName}
                 className='h-64 w-80 object-cover object-top'
               />

--- a/frontend/src/components/RoomCard.jsx
+++ b/frontend/src/components/RoomCard.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react'
 import { motion } from 'motion/react'
 import { AppContext } from '../context/AppContext'
 import { Tag, Clock } from 'lucide-react'
+import { getImageSrc } from '../utils/image'
 
 const RoomCard = ({ room }) => {
     const { navigate, isRoomDiscountActive, getCurrentRoomPrice, getDaysRemaining } = useContext(AppContext)
@@ -21,7 +22,7 @@ const RoomCard = ({ room }) => {
                 )}
                 
                 <img
-                    src={room.images[0]}
+                    src={getImageSrc(room.images[0])}
                     alt={room.roomType}
                     className='h-60 w-96 object-cover rounded-lg'
                 />

--- a/frontend/src/pages/HotelRooms.jsx
+++ b/frontend/src/pages/HotelRooms.jsx
@@ -4,6 +4,7 @@ import { MapPin, Star, ArrowLeft } from 'lucide-react'
 import { AppContext } from '../context/AppContext'
 import { toast } from 'react-hot-toast'
 import RoomCard from '../components/RoomCard'
+import { getImageSrc } from '../utils/image'
 
 const HotelRooms = () => {
   const { hotelId } = useParams()
@@ -63,7 +64,7 @@ const HotelRooms = () => {
           <div className='bg-gray-800 rounded-lg p-6 mb-8'>
             <div className='flex flex-col md:flex-row gap-6'>
               <img
-                src={hotelData.image}
+                src={getImageSrc(hotelData.image)}
                 alt={hotelData.hotelName}
                 className='w-full md:w-64 h-48 object-cover rounded-lg'
               />

--- a/frontend/src/pages/Hotels.jsx
+++ b/frontend/src/pages/Hotels.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import { AppContext } from '../context/AppContext'
 import { MapPin } from 'lucide-react';
+import { getImageSrc } from '../utils/image';
 
 const Hotels = () => {
   const { hotelData, navigate } = useContext(AppContext)
@@ -28,7 +29,7 @@ const Hotels = () => {
               onClick={() => handleHotelClick(item._id, item.hotelName)}
             >
               <img
-                src={item.image}
+                src={getImageSrc(item.image)}
                 alt={item.hotelName}
                 className='h-64 w-80 object-cover object-top'
               />

--- a/frontend/src/pages/MyBookings.jsx
+++ b/frontend/src/pages/MyBookings.jsx
@@ -3,6 +3,7 @@ import { MapPin, Calendar, Users, CreditCard, CheckCircle, Clock, XCircle, Eye, 
 import { useSearchParams } from 'react-router-dom'
 import { AppContext } from '../context/AppContext.jsx'
 import { toast } from 'react-hot-toast'
+import { getImageSrc } from '../utils/image'
 
 const MyBookings = () => {
 
@@ -260,7 +261,7 @@ const handlePayment = async(bookingId) => {
                       {/* Hotel & Room Info */}
                       <div className='col-span-1 md:col-span-4'>
                         <div className='flex gap-4'>
-                          <img src={booking.room.images[0]} alt={booking.room.roomType} className='w-20 h-14 md:w-24 md:h-20 rounded-lg object-cover flex-shrink-o' />
+                          <img src={getImageSrc(booking.room.images[0])} alt={booking.room.roomType} className='w-20 h-14 md:w-24 md:h-20 rounded-lg object-cover flex-shrink-o' />
                           <div className='flex-1 min-w-0'>
                             <h3 className='font-semibold text-gray-200 text-lg mb-1'>
                               {booking.hotel.hotelName}
@@ -415,7 +416,7 @@ const handlePayment = async(bookingId) => {
                       {/* Hotel & Room Info */}
                       <div className='col-span-3 md:col-span-5'>
                         <div className='flex gap-2 md:gap-4'>
-                          <img src={booking.room.images[0]} alt={booking.room.roomType} className='w-20 h-14 md:w-24 md:h-20 rounded-lg object-cover flex-shrink-o' />
+                          <img src={getImageSrc(booking.room.images[0])} alt={booking.room.roomType} className='w-20 h-14 md:w-24 md:h-20 rounded-lg object-cover flex-shrink-o' />
                           <div className='flex-1 min-w-0'>
                             <h3 className='font-semibold text-gray-200 text-lg mb-1'>
                               {booking.hotel.hotelName}

--- a/frontend/src/pages/SingularRoom.jsx
+++ b/frontend/src/pages/SingularRoom.jsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom"
 import { AppContext } from '../context/AppContext'
 import { Bath, Building, Car, Coffee, Eye, Mountain, TreePine, Tv, User, Utensils, Wifi, MapPin, Star, CheckCircle, XCircle, Phone, WavesLadder, UtensilsCrossed, Bubbles, MartiniIcon, Wine, Volleyball, BrickWallFire, CableCar, Dumbbell, BriefcaseBusiness, EggFried, Rose, Binoculars, Calendar, HousePlus, Gift, Info, Tag, Clock, AlertCircle } from "lucide-react"
 import {toast} from 'react-hot-toast'
+import { getImageSrc } from '../utils/image'
 
 const SingularRoom = () => {
   const { roomData, axios, navigate, user } = useContext(AppContext)
@@ -415,14 +416,14 @@ const onSubmitHandler = async (e) => {
           </h2>
           <div className='grid lg:grid-cols-3 gap-6'>
             <div className='lg:col-span-2'>
-              <img src={room.images[selectedImage]}
+              <img src={getImageSrc(room.images[selectedImage])}
               alt={`${room.roomType} - Image ${selectedImage + 1}`}
               className='w-full h-96 object-cover rounded-xl'/>
             </div>
               <div className='grid grid-cols-2 lg:grid-cols-1 gap-4'>
               {
                   room.images.map((image, index) => (
-                    <img key={index} src={image} alt={`Thumbnail ${index + 1}`}
+                    <img key={index} src={getImageSrc(image)} alt={`Thumbnail ${index + 1}`}
                       className={`h-24 lg:h-20 object-cover rounded-lg cursor-pointer transition-all duration-200
                         ${
                           selectedImage === index

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from 'react'
 import { User, Mail, Phone, Calendar, Star, Gift, MapPin, CreditCard, CheckCircle, Clock, XCircle, Edit3, Save, X } from "lucide-react"
 import { AppContext } from '../context/AppContext.jsx'
 import { toast } from 'react-hot-toast'
+import { getImageSrc } from '../utils/image'
 
 const UserProfile = () => {
   const { axios, navigate } = useContext(AppContext)
@@ -348,9 +349,9 @@ const fetchUserBookings = async () => {
                   return (
                     <div key={booking._id} className='p-6 hover:bg-gray-800/50 transition-colors'>
                       <div className='flex gap-4'>
-                        <img 
-                          src={booking.room.images[0]}
-                          alt={booking.room.roomType} 
+                        <img
+                          src={getImageSrc(booking.room.images[0])}
+                          alt={booking.room.roomType}
                           className='w-16 h-16 rounded-lg object-cover'
                         />
                         <div className='flex-1 min-w-0'>

--- a/frontend/src/pages/owner/AllHotels.jsx
+++ b/frontend/src/pages/owner/AllHotels.jsx
@@ -3,6 +3,7 @@ import { AppContext } from '../../context/AppContext';
 import { motion } from 'framer-motion';
 import { CircleUserRound, MapPin, Star, Trash2 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
+import { getImageSrc } from '../../utils/image';
 
 const AllHotels = () => {
   const { navigate, axios } = useContext(AppContext);
@@ -120,12 +121,12 @@ const AllHotels = () => {
                     <td className="py-6 px-4">
                       <div className="flex items-center space-x-4">
                         <img
-                          src={hotel.image}
+                          src={getImageSrc(hotel.image)}
                           alt={hotel.hotelName}
                           className="w-20 h-16 rounded-xl object-cover shadow-md"
                         />
                           <img
-                            src={hotel.image}
+                            src={getImageSrc(hotel.image)}
                             alt={hotel.hotelName}
                             className="w-20 h-16 rounded-xl object-cover shadow-md"
                           />
@@ -199,12 +200,12 @@ const AllHotels = () => {
               className="bg-gray-800 rounded-xl shadow-xl p-4 flex flex-col space-y-4"
             >
               <img
-                src={hotel.image}
+                src={getImageSrc(hotel.image)}
                 alt={hotel.hotelName}
                 className="w-full h-40 rounded-lg object-cover"
               />
                 <img
-                  src={hotel.image}
+                  src={getImageSrc(hotel.image)}
                   alt={hotel.hotelName}
                   className="w-full h-40 rounded-lg object-cover"
                 />

--- a/frontend/src/pages/owner/AllRooms.jsx
+++ b/frontend/src/pages/owner/AllRooms.jsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion"
 import { CircleUserRound, MapPin, Star, Trash2, Edit2, Tag, Clock } from 'lucide-react'
 import {toast} from 'react-hot-toast'
 import RoomManagementModal from '../../components/RoomManagementModal'
+import { getImageSrc } from '../../utils/image'
 
 const AllRooms = () => {
   const { axios, navigate} = useContext(AppContext)
@@ -158,7 +159,7 @@ const AllRooms = () => {
                       <td className='p-6'>
                         <div className='flex items-center space-x-4'>
                           <div className='relative'>
-                            <img src={room.images[0]} alt={room.roomType} className='w-20 h-16 rounded-xl object-cover shadow-md' />
+                            <img src={getImageSrc(room.images[0])} alt={room.roomType} className='w-20 h-16 rounded-xl object-cover shadow-md' />
                             <div className='absolute inset-0 bg-gradient-to-t from-black-20 to-transparent rounded-xl'></div>
                             {discountActive && (
                               <div className="absolute -top-1 -right-1 bg-red-500 text-white text-xs px-1.5 py-0.5 rounded-full font-bold">
@@ -269,7 +270,7 @@ const AllRooms = () => {
                   </div>
                 )}
                 
-                <img src={room.images[0]} alt={room.roomType} className='w-full h-48 rounded-xl object-cover mb-4' />
+                <img src={getImageSrc(room.images[0])} alt={room.roomType} className='w-full h-48 rounded-xl object-cover mb-4' />
                 
                 <div className="flex justify-between items-start mb-4">
                   <div>

--- a/frontend/src/utils/image.js
+++ b/frontend/src/utils/image.js
@@ -1,0 +1,6 @@
+export const getImageSrc = (path = '') => {
+  if (typeof path !== 'string') return '';
+  return path.startsWith('http') ? path : `${import.meta.env.VITE_BACKEND_URL}/${path}`;
+};
+
+export default getImageSrc;


### PR DESCRIPTION
## Summary
- add `getImageSrc` helper to build absolute image URLs
- use `getImageSrc` for hotel and room `<img>` tags across pages and components

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 56 problems)


------
https://chatgpt.com/codex/tasks/task_e_68c7f29042cc8328bcf13faa0047ab27